### PR TITLE
grep

### DIFF
--- a/gitalias.txt
+++ b/gitalias.txt
@@ -274,7 +274,7 @@
   lost = !"git fsck | awk '/dangling commit/ {print $3}' | git show --format='SHA1: %C(yellow)%h%Creset %f' --stdin | awk '/SHA1/ {sub(\"SHA1: \", \"\"); print}'"
 
   # Find text in any commit ever
-  grep-all = !"git rev-list --all | xargs git grep '$1'"
+  grep-all = !"f() { git rev-list --all | xargs git grep \"$@\"; }; f"
 
   # Given a merge commit, find the span of commits that exist(ed).
   # Not so useful in itself, but used by other aliases.


### PR DESCRIPTION
The usage of '$1' requires either 'sh -c' or 'f() {}; f' trick.
And if it accepts one parameter why not all?