### PR TITLE
Use `git var GIT_EDITOR` to call editor

### DIFF
--- a/gitalias.txt
+++ b/gitalias.txt
@@ -483,17 +483,17 @@
   unstage = reset HEAD
 
   # Edit all files of the given type
-  edit-cached = !"f() { git ls-files --cached | sort -u ; }; \"${VISUAL:-${EDITOR:-vi}}\" `f`"
-  edit-deleted = !"f() { git ls-files --deleted | sort -u ; }; \"${VISUAL:-${EDITOR:-vi}}\" `f`"
-  edit-others = !"f() { git ls-files --others | sort -u ; }; \"${VISUAL:-${EDITOR:-vi}}\" `f`"
-  edit-ignored = !"f() { git ls-files --ignored | sort -u ; }; \"${VISUAL:-${EDITOR:-vi}}\" `f`"
-  edit-killed = !"f() { git ls-files --killed | sort -u ; }; \"${VISUAL:-${EDITOR:-vi}}\" `f`"
-  edit-modified = !"f() { git ls-files --modified | sort -u ; }; \"${VISUAL:-${EDITOR:-vi}}\" `f`"
-  edit-stage = !"f() { git ls-files --stage | cut -f2 | sort -u ; }; "${VISUAL:-${EDITOR:-vi}}" `f`"
+  edit-cached = !"f() { git ls-files --cached | sort -u ; }; `git var GIT_EDITOR` `f`"
+  edit-deleted = !"f() { git ls-files --deleted | sort -u ; }; `git var GIT_EDITOR` `f`"
+  edit-others = !"f() { git ls-files --others | sort -u ; }; `git var GIT_EDITOR` `f`"
+  edit-ignored = !"f() { git ls-files --ignored | sort -u ; }; `git var GIT_EDITOR` `f`"
+  edit-killed = !"f() { git ls-files --killed | sort -u ; }; `git var GIT_EDITOR` `f`"
+  edit-modified = !"f() { git ls-files --modified | sort -u ; }; `git var GIT_EDITOR` `f`"
+  edit-stage = !"f() { git ls-files --stage | cut -f2 | sort -u ; }; `git var GIT_EDITOR` `f`"
 
   # Editing and adding conflicted files: when we get many merge conflicts
   # and want to quickly solve them using an editor, then add the  files.
-  edit-unmerged = !"f() { git ls-files --unmerged | cut -f2 | sort -u ; }; "${VISUAL:-${EDITOR:-vi}}" `f`"
+  edit-unmerged = !"f() { git ls-files --unmerged | cut -f2 | sort -u ; }; `git var GIT_EDITOR` `f`"
   add-unmerged = !"f() { git ls-files --unmerged | cut -f2 | sort -u ; }; git add `f`"
 
   # Ours & Theirs - easy merging when you know which files you want


### PR DESCRIPTION
`git var GIT_EDITOR` is better than ${VISUAL:-${EDITOR:-vi}} because
it takes into account all variables: GIT_EDITOR, VISUAL and EDITOR,
and falls back to the platform's default.