### PR TITLE
Add rename-alias alias at alias management

### DIFF
--- a/gitalias.txt
+++ b/gitalias.txt
@@ -284,7 +284,7 @@
   add-alias = "!f() { [ $# = 3 ] && git config $1 alias.\"$2\" \"$3\" && return 0 || echo \"Usage: git add-(local|global)-alias <new alias> <original command>\" >&2 && return 1; }; f"
   add-global-alias = "!git add-alias --global"
   add-local-alias = "!git add-alias --local"
-  rename-alias = "!f() { [ $# = 2 ] && [ $1 != $2 ] && [ ! -z \"$(git config --global --get alias.$1)\" ] && [ -z \"$(git config --global --get alias.$2)\" ] && git config --global alias.$2 \"$(git config --global --get alias.$1)\" && git config --global --unset alias.$1 && echo \"Alias $1 renamed to $2\" && return 0 || echo \"Usage: git rename-alias <alias existing name> <new alias name>\nThe alias you are going to rename must exist and new name must not exist.\" >&2 && return 1; };f"
+  rename-alias = "!f() { [ $# = 2 ] && [ $1 != $2 ] && [ ! -z \"$(git config --global --get alias.$1)\" ] && [ -z \"$(git config --global --get alias.$2)\" ] && git config --global alias.$2 \"$(git config --global --get alias.$1)\" && git config --global --unset alias.$1 && return 0 || echo \"Usage: git rename-alias <alias existing name> <new alias name>\nThe alias you are going to rename must exist and new name must not exist.\" >&2 && return 1; };f"
 
   # Last tag in the current branch
   lasttag = describe --tags --abbrev=0

--- a/gitalias.txt
+++ b/gitalias.txt
@@ -284,7 +284,11 @@
   add-alias = "!f() { [ $# = 3 ] && git config $1 alias.\"$2\" \"$3\" && return 0 || echo \"Usage: git add-(local|global)-alias <new alias> <original command>\" >&2 && return 1; }; f"
   add-global-alias = "!git add-alias --global"
   add-local-alias = "!git add-alias --local"
-  rename-alias = "!f() { [ $# = 2 ] && [ $1 != $2 ] && [ ! -z \"$(git config --global --get alias.$1)\" ] && [ -z \"$(git config --global --get alias.$2)\" ] && git config --global alias.$2 \"$(git config --global --get alias.$1)\" && git config --global --unset alias.$1 && return 0 || echo \"Usage: git rename-alias <alias existing name> <new alias name>\nThe alias you are going to rename must exist and new name must not exist.\" >&2 && return 1; };f"
+
+  # Rename an alias
+  rename-alias = "!f() { [ $# = 3 ] && [ $2 != $3 ] && [ ! -z \"$(git config $1 --get alias.$2)\" ] && [ -z \"$(git config $1 --get alias.$3)\" ] && git config $1 alias.$3 \"$(git config $1 --get alias.$2)\" && git config $1 --unset alias.$2 && return 0 || echo \"Usage: git rename-(local|global)-alias <alias existing name> <new alias name>\nThe alias you are going to rename must exist and new name must not exist.\" >&2 && return 1; };f"
+  rename-global-alias = "!git rename-alias --global"
+  rename-local-alias = "!git rename-alias --local"
 
   # Last tag in the current branch
   lasttag = describe --tags --abbrev=0

--- a/gitalias.txt
+++ b/gitalias.txt
@@ -284,6 +284,7 @@
   add-alias = "!f() { [ $# = 3 ] && git config $1 alias.\"$2\" \"$3\" && return 0 || echo \"Usage: git add-(local|global)-alias <new alias> <original command>\" >&2 && return 1; }; f"
   add-global-alias = "!git add-alias --global"
   add-local-alias = "!git add-alias --local"
+  rename-alias = "!f() { [ $# = 2 ] && [ $1 != $2 ] && [ ! -z \"$(git config --global --get alias.$1)\" ] && [ -z \"$(git config --global --get alias.$2)\" ] && git config --global alias.$2 \"$(git config --global --get alias.$1)\" && git config --global --unset alias.$1 && echo \"Alias $1 renamed to $2\" && return 0 || echo \"Usage: git rename-alias <alias existing name> <new alias name>\nThe alias you are going to rename must exist and new name must not exist.\" >&2 && return 1; };f"
 
   # Last tag in the current branch
   lasttag = describe --tags --abbrev=0
@@ -455,7 +456,7 @@
 
   # Clone a git repository including all submodules
   cloner = clone --recursive
-	
+
   # Stash aliases
   save = stash save
   pop = stash pop


### PR DESCRIPTION
Add rename alias:

Usage:
     
    git rename-(local|global)-alias <alias existing name> <new alias name>
<s>git rename-alias <alias existing name> <new alias name></s>

- Choose Local or global to use `--global` or `--local` options
- First parameter `<alias existing name>` must be an existing alias.
- Second parameter `<new alias name>`  must be an alias that does not exist.
- First parameter and second parameter must be different.
- There must be two parameters

Examples:

Success:

    git rename-local-alias ci comm
    git rename-global-alias ci comm
 <s>git rename-alias ci comm</s>
 <s>Alias comm renamed to ci</s>

Error:

    git rename-local-alias any ci
    Usage: git rename-alias <alias existing name> <new alias name>
    The alias you are going to rename must exist and new name must not exist.

    git rename-global-alias any ci
    Usage: git rename-alias <alias existing name> <new alias name>
    The alias you are going to rename must exist and new name must not exist.

 <s>git rename-alias any ci</s>