### PR TITLE
Add push commands

### DIFF
--- a/gitalias.txt
+++ b/gitalias.txt
@@ -177,6 +177,11 @@
   #
   pr = pull --rebase
 
+  ### push ###
+
+  po = push origin
+  pom = push origin master
+
   ### rebase ###
 
   # rebase - forward-port local commits to the updated upstream head.


### PR DESCRIPTION
I've added a section to `gitalias.txt` for push commands which I use frequently:

## po  
Useful for pushing to a branch, e.g: 

`$ git po dev`

## pom 
Shortcut for pushing to the master branch, e.g: 

`$ git pom`