### PR TITLE
Add alias to show commits in the current branch yet to be merged to master

### DIFF
--- a/gitalias.txt
+++ b/gitalias.txt
@@ -96,6 +96,9 @@
   # diff - show changes but by word, not line
   dw = diff --word-diff
 
+  # Show all commits in the current branch yet to be merged to master
+  db = cherry -v master
+
   ### clean ###
 
   # clean everything to be pristine


### PR DESCRIPTION
## Command

git db (The name means Diff Branch).

## Description

This alias is very useful for showing all commits that have not yet been merged with the master.

## How to use

git db (like as **git cherry -v master**)

### Result
+ 48e520f0f328c154dccc2f7def0ea4a81377ac4e message here
+ 48e520f0f328c154dccc2f7def0ea4a81377ac4e message here
+ 48e520f0f328c154dccc2f7def0ea4a81377ac4e message here