### PR TITLE
Create `cme` for empty commit

### DIFF
--- a/gitalias.txt
+++ b/gitalias.txt
@@ -129,6 +129,9 @@
 
   # commit with a message
   cm = commit --message
+  
+  # commit - empty with a message
+  cme = commit --allow-empty --message
 
   ### checkout ###
 


### PR DESCRIPTION
`cme` as a commit git alias for conventional empty commits