### PR TITLE
feat(checkout): add --no-guess option

### DIFF
--- a/gitalias.txt
+++ b/gitalias.txt
@@ -75,7 +75,7 @@
   g = grep
   l = log
   m = merge
-  o = checkout
+  o = checkout///
   p = pull
   r = remote
   s = status
@@ -139,6 +139,7 @@
 
   # checkout - update the working tree to match a branch or paths. [same as "o" for "out"]
   co = checkout
+  con = checkout --no-guess
 
   ### cherry-pick ###
 

--- a/gitalias.txt
+++ b/gitalias.txt
@@ -75,7 +75,7 @@
   g = grep
   l = log
   m = merge
-  o = checkout///
+  o = checkout
   p = pull
   r = remote
   s = status


### PR DESCRIPTION
The repo is awesome! utilizing it every day only to find new git commands I was unaware of until then.

This pr is to propose a `--no-guess` option to the `checkout` command
Often auto-completion in `checkout` results in unwanted remote repositories.
This option enables users to checkout only useful branches

Source:
https://stackoverflow.com/questions/6623649/disable-auto-completion-of-remote-branches-in-git-bash