### PR TITLE
Fix small typo in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -73,7 +73,7 @@ Example file `~/.gitconfig` with an entry to include the file `~/.gitalias.txt`:
 
 ```gitalias
 [include]
-  path = gitalias.txt
+  path = ~/.gitalias.txt
 ```
 
 


### PR DESCRIPTION
Fixes the value of example `path` in README that does not align with what's in the verbiage. 