### PR TITLE
Add 'ma' and 'mc' aliases

### DIFF
--- a/gitalias.txt
+++ b/gitalias.txt
@@ -218,14 +218,14 @@
 
   ### merge ###
 
-  # merge but without autocommit, and with a commit even if the merge resolved as a fast-forward.
-  me = merge --no-commit --no-ff
-
   # merge abort - cancel the merging process
   ma = merge --abort
 
   # merge - continue the merging process
   mc = merge --continue
+
+  # merge but without autocommit, and with a commit even if the merge resolved as a fast-forward.
+  me = merge --no-commit --no-ff
 
   ### pull ###
 

--- a/gitalias.txt
+++ b/gitalias.txt
@@ -221,6 +221,12 @@
   # merge but without autocommit, and with a commit even if the merge resolved as a fast-forward.
   me = merge --no-commit --no-ff
 
+  # merge abort - cancel the merging process
+  ma = merge --abort
+
+  # merge - continue the merging process
+  mc = merge --continue
+
   ### pull ###
 
   # pull if a merge can be resolved as a fast-forward, otherwise fail.


### PR DESCRIPTION
After using this gitaliases file, I found myself often using the `git cpa`, `git cpc`, `git rba`, & `git rbc` aliases.

When doing merges, my instinct is to type `git ma` & `git mc` commands, but these are not currently available.

I have added these aliases to my local git config, but thought I'd go ahead & and a PR to see if anyone else would find these useful.