### PR TITLE
Fix gitalias.com typo

### DIFF
--- a/gitalias.txt
+++ b/gitalias.txt
@@ -43,7 +43,7 @@
 #
 # ## Links
 #
-#   * [GitAlias.com website](http://gitlias.com)
+#   * [GitAlias.com website](http://gitalias.com)
 #   * [GitAlias GitHub](https://github.com/gitalias)
 #   * [Git Basics - Git Aliases](https://git-scm.com/book/en/v2/Git-Basics-Git-Aliases)
 #   * [Git Basics - Tips and Tricks](https://git-scm.com/book/en/v1/Git-Basics-Tips-and-Tricks)


### PR DESCRIPTION
Currently points to `gitlias.com`, should point to `gitalias.com`