### PR TITLE
Fix diff-chunk

### DIFF
--- a/gitalias.txt
+++ b/gitalias.txt
@@ -1392,13 +1392,13 @@
   #
   # Syntax:
   #
-  #     git funcdiff <old-rev> <new-rev> <path> <chunk pattern>
+  #     git diff-chunk <old-rev> <new-rev> <path> <chunk pattern>
   #
   diff-chunk = "!f() { \
-      git show \"\$1:\$3\" | sed -n \"/^[^ \t].*\$4(/,/^}/p\" > .tmp1 ; \
-      git show \"\$2:\$3\" | sed -n \"/^[^ \t].*\$4(/,/^}/p\" > .tmp2 ; \
-      git diff --no-index .tmp1 .tmp2 ; \
-  }; f"    
+    git show \"$1:$3\" | sed -n \"/^[^ \t].*$4(/,/^}/p\" > .tmp1 ; \
+    git show \"$2:$3\" | sed -n \"/^[^ \t].*$4(/,/^}/p\" > .tmp2 ; \
+    git diff --no-index .tmp1 .tmp2 ; \
+  }; f"
 
   # Calling "interdiff" between commits: if upstream applied a
   # slightly modified patch, and we want to see the modifications,


### PR DESCRIPTION
No backslash (`\`) character is needed before arguments.