### PR TITLE
Fix 'rbi' alias

### DIFF
--- a/gitalias.txt
+++ b/gitalias.txt
@@ -353,7 +353,7 @@
   rbs = rebase --skip
 
   # rebase interactive - do the rebase with prompts.
-  rbi = rebase --skip
+  rbi = rebase --interactive
 
   # rbiu - rebase interactive on our unpushed commits.
   #


### PR DESCRIPTION
Looks like the interactive rebase alias wasn't using the `--interactive` flag and was using `--skip`.