### PR TITLE
feature/change-refs-to-main Change references to main instead of master

### DIFF
--- a/README.md
+++ b/README.md
@@ -69,7 +69,7 @@ We often work on teams, across many companies and organizations, and using multi
 Download the file [`gitalias.txt`](gitalias.txt) and include it:
 
 ```sh
-curl https://raw.githubusercontent.com/GitAlias/gitalias/master/gitalias.txt -o ~/.gitalias 
+curl https://raw.githubusercontent.com/GitAlias/gitalias/main/gitalias.txt -o ~/.gitalias 
 git config --global include.path ~/.gitalias
 ```
 
@@ -79,7 +79,7 @@ git config --global include.path ~/.gitalias
 Download the file [`gitalias.txt`](gitalias.txt) any way you want, such as:
 
 ```sh
-curl -O https://raw.githubusercontent.com/GitAlias/gitalias/master/gitalias.txt
+curl -O https://raw.githubusercontent.com/GitAlias/gitalias/main/gitalias.txt
 ```
 
 Manually edit your git config dot file any way you want, such as:
@@ -234,9 +234,9 @@ unpublish = "!git push origin :$(git current-branch)"
 Branching:
 
 ```gitalias
-topic-start = "!f(){ b=$1; git checkout master; git fetch; git rebase; git checkout -b "$b" master; };f"
+topic-start = "!f(){ b=$1; git checkout main; git fetch; git rebase; git checkout -b "$b" main; };f"
 
-topic-stop = "!f(){ b=$1; git checkout master; git branch -d "$b"; git push origin ":$b"; };f"
+topic-stop = "!f(){ b=$1; git checkout main; git branch -d "$b"; git push origin ":$b"; };f"
 ```
 
 

--- a/doc/examples/examples.md
+++ b/doc/examples/examples.md
@@ -125,9 +125,9 @@ unpublish = "!git push origin :$(git current-branch)"
 Branching:
 
 ```gitalias
-topic-start = "!f(){ b=$1; git checkout master; git fetch; git rebase; git checkout -b "$b" master; };f"
+topic-start = "!f(){ b=$1; git checkout main; git fetch; git rebase; git checkout -b "$b" main; };f"
 
-topic-stop = "!f(){ b=$1; git checkout master; git branch -d "$b"; git push origin ":$b"; };f"
+topic-stop = "!f(){ b=$1; git checkout main; git branch -d "$b"; git push origin ":$b"; };f"
 ```
 
 

--- a/doc/install/install.md
+++ b/doc/install/install.md
@@ -10,7 +10,7 @@ page_template = "base.html"
 Download the file [`gitalias.txt`](gitalias.txt) and include it:
 
 ```sh
-curl https://raw.githubusercontent.com/GitAlias/gitalias/master/gitalias.txt -o ~/.gitalias 
+curl https://raw.githubusercontent.com/GitAlias/gitalias/main/gitalias.txt -o ~/.gitalias 
 git config --global include.path ~/.gitalias
 ```
 
@@ -20,7 +20,7 @@ git config --global include.path ~/.gitalias
 Download the file [`gitalias.txt`](gitalias.txt) any way you want, such as:
 
 ```sh
-curl -O https://raw.githubusercontent.com/GitAlias/gitalias/master/gitalias.txt
+curl -O https://raw.githubusercontent.com/GitAlias/gitalias/main/gitalias.txt
 ```
 
 Manually edit your git config dot file any way you want, such as:


### PR DESCRIPTION
In several files the old "master" branch is still listed.
Even though github does an automatic redirect I changed it once to the current "main" branch.