### PR TITLE
Documentation install on windows

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,13 +28,13 @@ GitAlias is a collection of git version control alias settings that can help you
 
 ## Download, install, customize
 
-You can use GitAlias various ways:
+To use GitAlias:
 
-  * Download GitAlias code in one file: [gitalias.txt](gitalias.txt)
+  * Download GitAlias code: [gitalias.txt](gitalias.txt)
 
-  * Install GitAlias using a variety of ways: [install guide](doc/install/index.md).
+  * Install GitAlias: [install guide](doc/install/index.md).
 
-  * Customize the aliases as you wish: [customize guide](doc/customize/index.md).
+  * Optional: Customize the aliases as you wish: [customize guide](doc/customize/index.md).
 
 
 ## Follow us

--- a/doc/install/index.html
+++ b/doc/install/index.html
@@ -29,10 +29,15 @@
     <div class="content">
       <h1>Install</h1>
 <h2>Install with typical usage</h2>
-<p>Download the file <a href="gitalias.txt"><code>gitalias.txt</code></a> and include it:</p>
+<p>Download the file <a href="gitalias.txt"><code>gitalias.txt</code></a> and include it.</p>
+<h3>On Linux</h3>
 <pre><code class="language-shell">curl https://raw.githubusercontent.com/GitAlias/gitalias/main/gitalias.txt -o ~/.gitalias
-git config --global include.path ~/.gitalias
+  git config --global include.path ~/.gitalias
 </code></pre>
+<h3>On Windows</h3>
+  <p>Store the file in your home folder: <code>C:\Users\YourUserName\gitalias.txt</code></p>
+  <p>Then in GitBash or PowerShell run:</p>
+  <pre><code class="language-shell"> git config --global include.path ~/gitalias.txt </code></pre>
 <h2>Install with custom usage</h2>
 <p>Download the file <a href="gitalias.txt"><code>gitalias.txt</code></a> any way you want, such as:</p>
 <pre><code class="language-shell">curl -O https://raw.githubusercontent.com/GitAlias/gitalias/main/gitalias.txt

--- a/doc/install/index.md
+++ b/doc/install/index.md
@@ -3,13 +3,23 @@
 
 ## Install with typical usage
 
-Download the file [`gitalias.txt`](../../gitalias.txt) and include it:
+Download the file [`gitalias.txt`](../../gitalias.txt) and include it.
+
+### On Linux:
 
 ```shell
 curl https://raw.githubusercontent.com/GitAlias/gitalias/main/gitalias.txt -o ~/.gitalias
 git config --global include.path ~/.gitalias
 ```
 
+### On Windows:
+
+Store the file in your home folder: `C:\Users\YourUserName\gitalias.txt`
+
+Then in GitBash or PowerShell run:
+```shell
+git config --global include.path ~/gitalias.txt
+```
 
 ## Install with custom usage
 


### PR DESCRIPTION
Tested on Windows 11. I did not retest, but I am pretty sure it worked like this on Windows 10 as well.
I decided to keep the instructions in the gitalias.txt as is and to slightly rephrase the main readme so people would more likely really look into the installation instructions.