### PR TITLE
suggest adding --index to stash snapshot

### DIFF
--- a/doc/examples/index.md
+++ b/doc/examples/index.md
@@ -91,7 +91,7 @@ Preserving:
 Git alias:
 
 ```git
-snapshot = !git stash push "snapshot: $(date)" && git stash apply "stash@{0}"
+snapshot = !git stash push "snapshot: $(date)" && git stash apply "stash@{0}" --index
 
 archive = !"f() { top=$(rev-parse --show-toplevel); cd $top; tar cvf $top.tar $top ; }; f"
 ```

--- a/doc/git-snapshot/index.md
+++ b/doc/git-snapshot/index.md
@@ -5,7 +5,7 @@
 Git alias:
 
 ```git
-snapshot = !git stash push --include-untracked --message \"snapshot: $(date)\" && git stash apply \"stash@{0}\"
+snapshot = !git stash push --include-untracked --message \"snapshot: $(date)\" && git stash apply \"stash@{0}\" --index
 ```
 
 Example:

--- a/gitalias.txt
+++ b/gitalias.txt
@@ -1106,7 +1106,7 @@
   #
   # And seemingly no changes to your working tree.
   #
-  snapshot = !git stash push --include-untracked --message \"snapshot: $(date)\" && git stash apply \"stash@{0}\"
+  snapshot = !git stash push --include-untracked --message \"snapshot: $(date)\" && git stash apply \"stash@{0}\" --index
 
   # When you're a little worried that the world is coming to an end
   panic = !tar cvf ../panic.tar *


### PR DESCRIPTION
This PR suggests adding `--index` to the `git apply` command
that ends the `git snapshot` alias.

The reason is that otherwise, although, as you rightly say,
the working tree is restored so that it seems nothing has changed,
the index is destroyed.

But this way, there is no change in either the working tree
or the index, so it truly appears that the snapshot was taken
with _no_ visible effect of _any_ kind.