### PR TITLE
Adding Nix + Home Manager to installation documentation

### DIFF
--- a/doc/install/index.md
+++ b/doc/install/index.md
@@ -53,6 +53,39 @@ sudo curl https://raw.githubusercontent.com/GitAlias/gitalias/main/gitalias.txt 
 sudo git config --global include.path "$dir/gitalias.txt"
 ```
 
+#### For Nix with Home Manager
+
+You should get a `fetchFromGitHub`-snippet of the current version of the project via `nurl` with the following command:
+
+```bash
+nix run nixpkgs#nurl https://github.com/GitAlias/gitalias/
+> fetchFromGitHub {
+>   owner = "GitAlias";
+>   repo = "gitalias";
+>   rev = "7b941c3abbcee391b6bfc4f8d6b8372064245b49";
+>   hash = "sha256-IvHM6mRtoeVm01cUmTkKqjm6/n3Izau89B7MT69Afo0=";
+> }
+```
+
+This snippet can then be used inside your Home Manager configuration like so:
+
+```nix
+# link gitalias.txt from store to
+# $XDG_CONFIG_HOME/gitalias/gitalias.txt
+xdg.configFile = {
+    "gitalias/gitalias.txt".source = pkgs.fetchFromGitHub {
+        # fill with snippet here
+    } + "/gitalias.txt";
+};
+
+# tell git to include gitalias.txt
+programs.git = {
+    enable = true;
+    includes = [
+        { path = "${config.xdg.configHome}/gitalias/gitalias.txt"; }
+    ];
+};
+```
 
 ### For Windows
 


### PR DESCRIPTION
I've just been through the hassle of setting up gitalias on Nix with Home Manager and I thought I might make a small contribution by adding some info to the Installation doc. 