### PR TITLE
Remote argument for publish and unpublish

### DIFF
--- a/doc/examples/index.md
+++ b/doc/examples/index.md
@@ -135,9 +135,9 @@ Publishing:
 Git alias:
 
 ```git
-publish = "!git push -u origin $(git current-branch)"
+publish = "!f() { git push -u ${1:-origin} $(git current-branch); }; f"
 
-unpublish = "!git push origin :$(git current-branch)"
+unpublish = "!f() { git push ${1:-origin} :$(git current-branch); }; f"
 ```
 
 Branching:

--- a/doc/git-publish/index.md
+++ b/doc/git-publish/index.md
@@ -5,16 +5,20 @@
 Git alias:
 
 ```git
-publish = !"git push --set-upstream origin $(git current-branch)"
+publish = "!f() { git push --set-upstream ${1:-origin} $(git current-branch); }; f"
 ```
 
-Publish the current branch by pushing upstream to origin,
+Publish the current branch by pushing to the remote specified by the first argument (defaulting to origin),
 and setting the current branch to track the upstream branch.
 
 Example:
 
 ```shell
+# pushing to origin
 git publish
+
+# pushing to fork
+git publish fork
 ```
 
 Compare:

--- a/doc/git-unpublish/index.md
+++ b/doc/git-unpublish/index.md
@@ -5,16 +5,21 @@
 Git alias:
 
 ```git
-unpublish = !"git push origin :$(git current-branch)"
+unpublish = "!f() { git push ${1:-origin} :$(git current-branch); }; f"
 ```
 
 Unpublish the current branch by deleting the
 remote version of the current branch.
+The remote name may be specified by the first argument and defaults to `origin`.
 
 Example:
 
 ```shell
+# unpublish on origin
 git unpublish
+
+# unpublish branch on fork
+git unpublish fork
 ```
 
 Compare:

--- a/gitalias.txt
+++ b/gitalias.txt
@@ -1372,11 +1372,11 @@
 
   # Publish the current branch by pushing it to the remote "origin",
   # and setting the current branch to track the upstream branch.
-  publish = "!git push --set-upstream origin \"$(git current-branch)\""
+  publish = "!f() { git push --set-upstream \"${1:-origin}\" \"$(git current-branch)\"; }; f"
 
   # Unpublish the current branch by deleting the
   # remote version of the current branch.
-  unpublish = "!git push origin :\"$(git current-branch)\""
+  unpublish = "!f() { git push \"${1:-origin}\" :\"$(git current-branch)\"; }; f"
 
   ### inbound & outbound ###
 


### PR DESCRIPTION
Adding an optional argument to `publish` and `unpublish` to specify the affected remote.

Current behavior stays consistent, the argument defaults to `origin`.