### PR TITLE
Make it clearer that the command out of the box for installation requ…

### DIFF
--- a/doc/install/index.md
+++ b/doc/install/index.md
@@ -15,7 +15,7 @@ curl https://raw.githubusercontent.com/GitAlias/gitalias/main/gitalias.txt -o gi
 Run `git config` to include the file as you wish, such as:
 
 ```shell
-git config --global include.path gitalias.txt
+git config --global include.path {PATH_TO_YOUR_DIRECTORY}/gitalias.txt
 ```
 
 


### PR DESCRIPTION
…ires a path to be appended

It took me a few minutes of debugging including logging my git config to see that this had to be a proper path to the file for future references, not a one-off relative path to import the file once. 

Updating the docs to make it clearer.