### PR TITLE
Remove unnecessary !git

### DIFF
--- a/gitalias.txt
+++ b/gitalias.txt
@@ -1153,7 +1153,7 @@
   # git checks you're current with remote, and only then allows the push.
   # We name this `pushy` because its dsagreeably aggressive (in general)
   # or overly assertive (in general), yet still better than just --force.
-  pushy = !git push --force-with-lease
+  pushy = push --force-with-lease
 
   # Do everything we can to synchronize all changes for the current branch.
   #


### PR DESCRIPTION
Executing shell using `!git` is unnecessary, because Git aliases by default prepend `git` to simple commands that don't start with `!`. Simpler version:
- Does exactly the same thing
- Is more concise
- Is more idiomatic Git alias syntax
- Avoids unnecessary shell execution overhead