### PR TITLE
Correct links to documentation for `hew` aliases

### DIFF
--- a/README.md
+++ b/README.md
@@ -264,9 +264,9 @@ New repos:
 Hew branches:
 
   * [git hew](doc/git-hew/) - Delete all branches that are merged into a commit
-  * [git hew-dry-run](doc/git-hew/) - Delete all branches that are merged into a commit (dry run)
+  * [git hew-dry-run](doc/git-hew-dry-run/) - Delete all branches that are merged into a commit (dry run)
   * [git hew-local](doc/git-hew-local/) - Delete local branches that are merged into a commit
-  * [git hew-local-dry-run](doc/git-hew-local/) - Delete local branches that are merged (dry run)
+  * [git hew-local-dry-run](doc/git-hew-local-dry-run/) - Delete local branches that are merged (dry run)
   * [git hew-remote](doc/git-hew-remote/) - Delete remote branches that are merged into a commit
   * [git hew-remote-dry-run](doc/git-hew-remote-dry-run/) - Delete remote branches that are merged into a commit (dry run)
 


### PR DESCRIPTION
Correct links to documentation of the following 2 commands:

* `git hew-dry-run`
* `git hew-local-dry-run`