### PR TITLE
Add git worktree aliases

### DIFF
--- a/README.md
+++ b/README.md
@@ -182,6 +182,18 @@ git whatchanged:
 
   * [git w](doc/git-w/) = whatchanged
 
+git worktree:
+
+  * [git wt](doc/git-wt/) = worktree
+  * [git wta](doc/git-wta/) = worktree add
+  * [git wtl](doc/git-wtl/) = worktree list
+  * [git wtlo](doc/git-wtlo/) = worktree lock
+  * [git wtm](doc/git-wtm/) = worktree move
+  * [git wtp](doc/git-wtp/) = worktree prune
+  * [git wtr](doc/git-wtr/) = worktree remove
+  * [git wtrp](doc/git-wtrp/) = worktree repair
+  * [git wtul](doc/git-wtul/) = worktree unlock
+
 
 ## Friendly aliases
 
@@ -652,6 +664,15 @@ Use graphviz:
   * [git who](doc/git-who/) - Show a short log of who has contributed commits, in descending order
   * [git whois](doc/git-whois/) - Given a string for an author, try to figure out full name and email
   * [git wip](doc/git-wip/) - Save "work in progress"
+  * [git wt](doc/git-wt/) - Short for "git worktree"
+  * [git wta](doc/git-wta/) - Worktree add i.e. create a new working tree at a given path
+  * [git wtl](doc/git-wtl/) - Worktree list i.e. list all working trees
+  * [git wtlo](doc/git-wtlo/) - Worktree lock i.e. lock a working tree to prevent it from being pruned
+  * [git wtm](doc/git-wtm/) - Worktree move i.e. move a working tree to a new location
+  * [git wtp](doc/git-wtp/) - Worktree prune i.e. prune working tree information
+  * [git wtr](doc/git-wtr/) - Worktree remove i.e. remove a working tree
+  * [git wtrp](doc/git-wtrp/) - Worktree repair i.e. repair worktree administrative files
+  * [git wtul](doc/git-wtul/) - Worktree unlock i.e. unlock a working tree to allow it to be pruned
 
 
 ### Tracking

--- a/doc/git-wt/README.md
+++ b/doc/git-wt/README.md
@@ -1,0 +1,1 @@
+index.md

--- a/doc/git-wt/index.md
+++ b/doc/git-wt/index.md
@@ -1,0 +1,19 @@
+# git wt
+
+## Short for "git worktree"
+
+Git alias:
+
+```git
+wt = worktree
+```
+
+Example:
+
+```shell
+git wt
+```
+
+Worktree manages multiple working trees attached to the same repository.
+
+See also: [git wta](../git-wta/), [git wtl](../git-wtl/), [git wtlo](../git-wtlo/), [git wtm](../git-wtm/), [git wtp](../git-wtp/), [git wtr](../git-wtr/), [git wtrp](../git-wtrp/), [git wtul](../git-wtul/)

--- a/doc/git-wta/README.md
+++ b/doc/git-wta/README.md
@@ -1,0 +1,1 @@
+index.md

--- a/doc/git-wta/index.md
+++ b/doc/git-wta/index.md
@@ -1,0 +1,17 @@
+# git wta
+
+## Worktree add i.e. create a new working tree at a given path
+
+Git alias:
+
+```git
+wta = worktree add
+```
+
+Example:
+
+```shell
+git wta ../my-feature my-feature
+```
+
+Worktree add creates a new working tree linked to the repository at the given path, optionally checking out the given branch.

--- a/doc/git-wtl/README.md
+++ b/doc/git-wtl/README.md
@@ -1,0 +1,1 @@
+index.md

--- a/doc/git-wtl/index.md
+++ b/doc/git-wtl/index.md
@@ -1,0 +1,17 @@
+# git wtl
+
+## Worktree list i.e. list all working trees
+
+Git alias:
+
+```git
+wtl = worktree list
+```
+
+Example:
+
+```shell
+git wtl
+```
+
+Worktree list shows all working trees, including the main working tree and any linked working trees.

--- a/doc/git-wtlo/README.md
+++ b/doc/git-wtlo/README.md
@@ -1,0 +1,1 @@
+index.md

--- a/doc/git-wtlo/index.md
+++ b/doc/git-wtlo/index.md
@@ -1,0 +1,17 @@
+# git wtlo
+
+## Worktree lock i.e. lock a working tree to prevent it from being pruned
+
+Git alias:
+
+```git
+wtlo = worktree lock
+```
+
+Example:
+
+```shell
+git wtlo ../my-feature
+```
+
+Worktree lock prevents a working tree from being pruned, for example when the working tree is stored on a removable device that is not always mounted.

--- a/doc/git-wtm/README.md
+++ b/doc/git-wtm/README.md
@@ -1,0 +1,1 @@
+index.md

--- a/doc/git-wtm/index.md
+++ b/doc/git-wtm/index.md
@@ -1,0 +1,17 @@
+# git wtm
+
+## Worktree move i.e. move a working tree to a new location
+
+Git alias:
+
+```git
+wtm = worktree move
+```
+
+Example:
+
+```shell
+git wtm ../my-feature ../my-feature-new
+```
+
+Worktree move moves a linked working tree to a new path.

--- a/doc/git-wtp/README.md
+++ b/doc/git-wtp/README.md
@@ -1,0 +1,1 @@
+index.md

--- a/doc/git-wtp/index.md
+++ b/doc/git-wtp/index.md
@@ -1,0 +1,17 @@
+# git wtp
+
+## Worktree prune i.e. prune working tree information
+
+Git alias:
+
+```git
+wtp = worktree prune
+```
+
+Example:
+
+```shell
+git wtp
+```
+
+Worktree prune removes stale working tree administrative files from $GIT_DIR, for example after a linked working tree has been deleted manually.

--- a/doc/git-wtr/README.md
+++ b/doc/git-wtr/README.md
@@ -1,0 +1,1 @@
+index.md

--- a/doc/git-wtr/index.md
+++ b/doc/git-wtr/index.md
@@ -1,0 +1,17 @@
+# git wtr
+
+## Worktree remove i.e. remove a working tree
+
+Git alias:
+
+```git
+wtr = worktree remove
+```
+
+Example:
+
+```shell
+git wtr ../my-feature
+```
+
+Worktree remove deletes a linked working tree. The working tree must be clean; use -f to force removal of an unclean working tree.

--- a/doc/git-wtrp/README.md
+++ b/doc/git-wtrp/README.md
@@ -1,0 +1,1 @@
+index.md

--- a/doc/git-wtrp/index.md
+++ b/doc/git-wtrp/index.md
@@ -1,0 +1,17 @@
+# git wtrp
+
+## Worktree repair i.e. repair worktree administrative files
+
+Git alias:
+
+```git
+wtrp = worktree repair
+```
+
+Example:
+
+```shell
+git wtrp ../my-feature
+```
+
+Worktree repair fixes worktree administrative files if they have become corrupted or outdated, for example after moving the main or a linked working tree.

--- a/doc/git-wtul/README.md
+++ b/doc/git-wtul/README.md
@@ -1,0 +1,1 @@
+index.md

--- a/doc/git-wtul/index.md
+++ b/doc/git-wtul/index.md
@@ -1,0 +1,17 @@
+# git wtul
+
+## Worktree unlock i.e. unlock a working tree to allow it to be pruned
+
+Git alias:
+
+```git
+wtul = worktree unlock
+```
+
+Example:
+
+```shell
+git wtul ../my-feature
+```
+
+Worktree unlock allows a working tree to be pruned again after it was previously locked with git worktree lock.

--- a/gitalias.txt
+++ b/gitalias.txt
@@ -199,7 +199,7 @@
 
   # Fetch all remotes and use verbose output
   fav = fetch --all --verbose
-  
+
   # Fetch all remotes and delete stale references associated with the remotes
   fap = fetch --all --prune
 
@@ -468,6 +468,35 @@
 
   # status with short format and showing branch and tracking info.
   ssb = status --short --branch
+
+  ### worktree aliases ###
+
+  # worktree - manage multiple working trees attached to the same repository.
+  wt = worktree
+
+  # worktree add - create a new working tree at a given path.
+  wta = worktree add
+
+  # worktree list - list all working trees.
+  wtl = worktree list
+
+  # worktree lock - lock a working tree to prevent it from being pruned.
+  wtlo = worktree lock
+
+  # worktree move - move a working tree to a new location.
+  wtm = worktree move
+
+  # worktree prune - prune working tree information in $GIT_DIR.
+  wtp = worktree prune
+
+  # worktree remove - remove a working tree.
+  wtr = worktree remove
+
+  # worktree repair - repair worktree administrative files.
+  wtrp = worktree repair
+
+  # worktree unlock - unlock a working tree to allow it to be pruned.
+  wtul = worktree unlock
 
   ### alias management aliases ###
 


### PR DESCRIPTION
# Context
Hi all, I'm a long term user of these aliases.
I've recently started using `git worktree` command frequently and I thought it could benefit from an alias.
As `w` is taken, I feel `wt` naturally maps to `worktree`.

The aliases are summarised below:

Alias | Command | Description |
|-------|---------|-------------|
| `wt` | `git worktree` | Manage multiple working trees attached to the same repository |
| `wta` | `git worktree add` | Create a new working tree at a given path |
| `wtl` | `git worktree list` | List all working trees |
| `wtlo` | `git worktree lock` | Lock a working tree to prevent it from being pruned |
| `wtm` | `git worktree move` | Move a working tree to a new location |
| `wtp` | `git worktree prune` | Prune stale working tree administrative files |
| `wtr` | `git worktree remove` | Remove a working tree |
| `wtrp` | `git worktree repair` | Repair worktree administrative files |
| `wtul` | `git worktree unlock` | Unlock a working tree to allow it to be pruned


# Questions
1. I did not update the semantic version or date timestamps in various locations. Let me know if I should also do that as part of this PR.
2. Potentially we could prefer `git wt` as the only alias and explicit usage of subcommands. So instead of `git wta` you would use `git wt add`. The current design is based on other aliases like `git submodule` which has individual mappings for subcommands.